### PR TITLE
Fix duplicate cards showing on many cases

### DIFF
--- a/app/src/main/java/com/katiearose/sobriety/Main.kt
+++ b/app/src/main/java/com/katiearose/sobriety/Main.kt
@@ -56,7 +56,8 @@ class Main : AppCompatActivity() {
         addCardButton.setOnClickListener { newCardDialog() }
         prompt = findViewById(R.id.prompt)
         cacheHandler = CacheHandler(this)
-        try {
+        if (addictions.isEmpty())
+            try {
             this.openFileInput("Sobriety.cache").use {
                 addictions.addAll(cacheHandler.readCache(it))
             }


### PR DESCRIPTION
I modified the Main activity's initialization logic to only fetch the addictions list when the list is empty (which is when the app is first started). This should completely prevent any duplication bugs in all cases.
If you wanna know the details: when the screen is rotated or the user switches between apps, etc. the Activity's `onCreate` method is called again, which executes the initialization logic. Since the list is re-fetched when that happens, the activity adds a duplicate of the list on top of it.