### PR TITLE
Improve time range calculations (closes #58)

### DIFF
--- a/app/src/main/java/com/katiearose/sobriety/AddictionCardAdapter.kt
+++ b/app/src/main/java/com/katiearose/sobriety/AddictionCardAdapter.kt
@@ -9,10 +9,12 @@ import androidx.core.content.res.ResourcesCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.katiearose.sobriety.activities.Main
 import com.katiearose.sobriety.databinding.CardAddictionBinding
+import com.katiearose.sobriety.utils.convertRangeToString
 import com.katiearose.sobriety.utils.convertSecondsToString
 import com.katiearose.sobriety.utils.secondsFromNow
 import kotlinx.coroutines.*
 import java.text.DateFormat
+import java.time.Instant
 import java.util.*
 import kotlin.math.absoluteValue
 
@@ -111,15 +113,15 @@ class AddictionCardAdapter(
             if (addiction.isFuture()) {
                 binding.textViewTime.text = binding.root.context.getString(
                     R.string.time_until_tracked,
-                    binding.root.context.convertSecondsToString(addiction.lastRelapse.secondsFromNow().absoluteValue)
+                    binding.root.context.convertRangeToString(Instant.now().toEpochMilli(), addiction.lastRelapse.toEpochMilli())
                 )
             } else {
                 binding.textViewTime.text =
-                    if (!addiction.isStopped) binding.root.context.convertSecondsToString(addiction.lastRelapse.secondsFromNow())
+                    if (!addiction.isStopped) binding.root.context.convertRangeToString(addiction.lastRelapse.toEpochMilli())
                     else binding.root.context.getString(
                         R.string.stop_notice,
                         dateFormat.format(Date(addiction.timeStopped)),
-                        binding.root.context.convertSecondsToString((addiction.timeStopped - addiction.lastRelapse.toEpochMilli()) / 1000)
+                        binding.root.context.convertRangeToString(addiction.lastRelapse.toEpochMilli(), addiction.timeStopped)
                     )
             }
         }

--- a/app/src/main/java/com/katiearose/sobriety/TimelineAdapter.kt
+++ b/app/src/main/java/com/katiearose/sobriety/TimelineAdapter.kt
@@ -8,7 +8,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.katiearose.sobriety.databinding.ListItemTimelineBinding
-import com.katiearose.sobriety.utils.convertSecondsToString
+import com.katiearose.sobriety.utils.convertRangeToString
 import java.text.DateFormat
 import java.util.*
 
@@ -47,7 +47,7 @@ class TimelineAdapter(addiction: Addiction, private val context: Context):
             holder.abstainPeriod.text = context.getString(R.string.ongoing)
         } else {
             holder.dateRange.text = context.getString(R.string.time_range, dateFormat.format(Date(pair.first)), dateFormat.format(Date(pair.second)))
-            holder.abstainPeriod.text = context.getString(R.string.duration, context.convertSecondsToString((pair.second - pair.first) / 1000))
+            holder.abstainPeriod.text = context.getString(R.string.duration, context.convertRangeToString(pair.first, pair.second))
         }
     }
 

--- a/app/src/main/java/com/katiearose/sobriety/utils/Utils.kt
+++ b/app/src/main/java/com/katiearose/sobriety/utils/Utils.kt
@@ -18,7 +18,7 @@ private const val MINUTE = 60
 private const val HOUR = MINUTE * 60
 private const val DAY = HOUR * 24
 private const val WEEK = DAY * 7
-private const val YEAR = DAY * 365
+private const val YEAR = (DAY * 365.25).toInt()
 private const val MONTH = YEAR / 12
 
 

--- a/app/src/main/java/com/katiearose/sobriety/utils/Utils.kt
+++ b/app/src/main/java/com/katiearose/sobriety/utils/Utils.kt
@@ -9,13 +9,18 @@ import androidx.preference.PreferenceManager
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.katiearose.sobriety.R
 import java.time.Instant
+import java.time.LocalDateTime
+import java.time.Period
+import java.time.Duration
+import java.util.TimeZone
 
 private const val MINUTE = 60
 private const val HOUR = MINUTE * 60
 private const val DAY = HOUR * 24
 private const val WEEK = DAY * 7
-private const val MONTH = DAY * 31
-private const val YEAR = MONTH * 12
+private const val YEAR = DAY * 365
+private const val MONTH = YEAR / 12
+
 
 fun Context.convertSecondsToString(given: Long): String {
     if (given == -1L) return ""
@@ -41,6 +46,40 @@ fun Context.convertSecondsToString(given: Long): String {
     if (h != 0L) stringBuilder.append(getString(R.string.hours, h)).append(" ")
     if (m != 0L) stringBuilder.append(getString(R.string.minutes, m)).append(" ")
     if (!(y == 0L && mo == 0L && w == 0L && d == 0L && h == 0L && m == 0L)) stringBuilder.append(
+        getString(R.string.and)
+    ).append(" ")
+    stringBuilder.append(getString(R.string.seconds, s))
+    return stringBuilder.toString()
+}
+
+// Expects start and end timestamps in epoch milliseconds
+fun Context.convertRangeToString(start: Long, end: Long = Instant.now().toEpochMilli()): String {
+    if (start == -1L) return ""
+    val startDate: LocalDateTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(start),
+        TimeZone.getDefault().toZoneId())
+    val endDate: LocalDateTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(end),
+        TimeZone.getDefault().toZoneId())
+    // Period for years, months, weeks, days
+    val period: Period = Period.between(startDate.toLocalDate(), endDate.toLocalDate())
+    // Duration for hours, minutes, seconds
+    val duration: Duration = Duration.between(startDate, endDate)
+
+    val y = period.years
+    val mo = period.months
+    val d = period.days % 7
+    val w = period.days / 7
+    val h = duration.toHoursPart()
+    val m = duration.toMinutesPart()
+    val s = duration.toSecondsPart()
+
+    val stringBuilder = StringBuilder()
+    if (y != 0) stringBuilder.append(getString(R.string.years, y)).append(" ")
+    if (mo != 0) stringBuilder.append(getString(R.string.months, mo)).append(" ")
+    if (w != 0) stringBuilder.append(getString(R.string.weeks, w)).append(" ")
+    if (d != 0) stringBuilder.append(getString(R.string.days, d)).append(" ")
+    if (h != 0) stringBuilder.append(getString(R.string.hours, h)).append(" ")
+    if (m != 0) stringBuilder.append(getString(R.string.minutes, m)).append(" ")
+    if (!(y == 0 && mo == 0 && w == 0 && d == 0 && h == 0 && m == 0)) stringBuilder.append(
         getString(R.string.and)
     ).append(" ")
     stringBuilder.append(getString(R.string.seconds, s))


### PR DESCRIPTION
Month lengths are now calculated by java.time.Period rather than a uniform 31 days per month. This change applies to all time ranges except for the average time range. In that case, month length is changed to 365 days / 12 months.