### PR TITLE
Pass position, not a copy of addiction (fix #57)

### DIFF
--- a/app/src/main/java/com/katiearose/sobriety/activities/DailyNotes.kt
+++ b/app/src/main/java/com/katiearose/sobriety/activities/DailyNotes.kt
@@ -35,7 +35,9 @@ class DailyNotes : AppCompatActivity() {
         setContentView(binding.root)
         cacheHandler = CacheHandler(this)
 
-        addiction = intent.extras!!.getSerializable(Main.EXTRA_ADDICTION) as Addiction
+        val addictionPosition = intent.extras!!.getSerializable(Main.EXTRA_ADDICTION_POSITION) as Int
+        addiction = Main.addictions[addictionPosition]
+
         adapter = NoteAdapter(addiction, this, { showAddNoteDialog(true, it.first) },
             {
                 val action: () -> Unit = {

--- a/app/src/main/java/com/katiearose/sobriety/activities/DailyNotes.kt
+++ b/app/src/main/java/com/katiearose/sobriety/activities/DailyNotes.kt
@@ -35,9 +35,7 @@ class DailyNotes : AppCompatActivity() {
         setContentView(binding.root)
         cacheHandler = CacheHandler(this)
 
-        val addictionPosition = intent.extras!!.getSerializable(Main.EXTRA_ADDICTION_POSITION) as Int
-        addiction = Main.addictions[addictionPosition]
-
+        addiction = Main.addictions[intent.getIntExtra(Main.EXTRA_ADDICTION_POSITION, 0)]
         adapter = NoteAdapter(addiction, this, { showAddNoteDialog(true, it.first) },
             {
                 val action: () -> Unit = {

--- a/app/src/main/java/com/katiearose/sobriety/activities/Main.kt
+++ b/app/src/main/java/com/katiearose/sobriety/activities/Main.kt
@@ -36,9 +36,7 @@ class Main : AppCompatActivity() {
 
     companion object {
         const val EXTRA_NAMES = "com.katiearose.sobriety.EXTRA_NAMES"
-        // Use this to get a copy of the addiction
-        const val EXTRA_ADDICTION = "com.katiearose.sobriety.EXTRA_ADDICTION"
-        // Use this when the addiction needs to be modified
+        // Pass the position of the addiction so that it can be modified
         const val EXTRA_ADDICTION_POSITION = "com.katiearose.sobriety.EXTRA_ADDICTION_POSITION"
         val addictions = ArrayList<Addiction>()
     }
@@ -176,7 +174,7 @@ class Main : AppCompatActivity() {
             if (!it.isFuture()) {
                 startActivity(
                     Intent(this@Main, Timeline::class.java)
-                        .putExtra(EXTRA_ADDICTION, it)
+                        .putExtra(EXTRA_ADDICTION_POSITION, addictions.indexOf(it))
                 )
             } else Snackbar.make(
                 binding.root,

--- a/app/src/main/java/com/katiearose/sobriety/activities/Main.kt
+++ b/app/src/main/java/com/katiearose/sobriety/activities/Main.kt
@@ -36,7 +36,10 @@ class Main : AppCompatActivity() {
 
     companion object {
         const val EXTRA_NAMES = "com.katiearose.sobriety.EXTRA_NAMES"
+        // Use this to get a copy of the addiction
         const val EXTRA_ADDICTION = "com.katiearose.sobriety.EXTRA_ADDICTION"
+        // Use this when the addiction needs to be modified
+        const val EXTRA_ADDICTION_POSITION = "com.katiearose.sobriety.EXTRA_ADDICTION_POSITION"
         val addictions = ArrayList<Addiction>()
     }
 
@@ -207,21 +210,21 @@ class Main : AppCompatActivity() {
             dialogViewBinding!!.dailyNotes.setOnClickListener {
                 startActivity(
                     Intent(this@Main, DailyNotes::class.java)
-                        .putExtra(EXTRA_ADDICTION, a)
+                        .putExtra(EXTRA_ADDICTION_POSITION, addictions.indexOf(a))
                 )
                 dialog.dismiss()
             }
             dialogViewBinding.savings.setOnClickListener {
                 startActivity(
                     Intent(this@Main, Savings::class.java)
-                        .putExtra(EXTRA_ADDICTION, a)
+                        .putExtra(EXTRA_ADDICTION_POSITION, addictions.indexOf(a))
                 )
                 dialog.dismiss()
             }
             dialogViewBinding.milestones.setOnClickListener {
                 startActivity(
                     Intent(this@Main, Milestones::class.java)
-                        .putExtra(EXTRA_ADDICTION, a)
+                        .putExtra(EXTRA_ADDICTION_POSITION, addictions.indexOf(a))
                 )
                 dialog.dismiss()
             }

--- a/app/src/main/java/com/katiearose/sobriety/activities/Milestones.kt
+++ b/app/src/main/java/com/katiearose/sobriety/activities/Milestones.kt
@@ -29,9 +29,7 @@ class Milestones : AppCompatActivity() {
         setContentView(binding.root)
         cacheHandler = CacheHandler(this)
 
-        val addictionPosition = intent.extras!!.getSerializable(Main.EXTRA_ADDICTION_POSITION) as Int
-        addiction = Main.addictions[addictionPosition]
-
+        addiction = Main.addictions[intent.getIntExtra(Main.EXTRA_ADDICTION_POSITION, 0)]
         adapter = MilestoneAdapter(addiction, this) {
             val action: () -> Unit = {
                 addiction.milestones.remove(it)

--- a/app/src/main/java/com/katiearose/sobriety/activities/Milestones.kt
+++ b/app/src/main/java/com/katiearose/sobriety/activities/Milestones.kt
@@ -29,7 +29,9 @@ class Milestones : AppCompatActivity() {
         setContentView(binding.root)
         cacheHandler = CacheHandler(this)
 
-        addiction = intent.extras!!.getSerializable(Main.EXTRA_ADDICTION) as Addiction
+        val addictionPosition = intent.extras!!.getSerializable(Main.EXTRA_ADDICTION_POSITION) as Int
+        addiction = Main.addictions[addictionPosition]
+
         adapter = MilestoneAdapter(addiction, this) {
             val action: () -> Unit = {
                 addiction.milestones.remove(it)

--- a/app/src/main/java/com/katiearose/sobriety/activities/Savings.kt
+++ b/app/src/main/java/com/katiearose/sobriety/activities/Savings.kt
@@ -34,9 +34,7 @@ class Savings : AppCompatActivity() {
         setContentView(binding.root)
         cacheHandler = CacheHandler(this)
 
-        val addictionPosition = intent.extras!!.getSerializable(Main.EXTRA_ADDICTION_POSITION) as Int
-        addiction = Main.addictions[addictionPosition]
-
+        addiction = Main.addictions[intent.getIntExtra(Main.EXTRA_ADDICTION_POSITION, 0)]
         updateSavedTimeDisplay()
 
         binding.btnEditTime.setOnClickListener {

--- a/app/src/main/java/com/katiearose/sobriety/activities/Savings.kt
+++ b/app/src/main/java/com/katiearose/sobriety/activities/Savings.kt
@@ -34,7 +34,9 @@ class Savings : AppCompatActivity() {
         setContentView(binding.root)
         cacheHandler = CacheHandler(this)
 
-        addiction = intent.extras!!.getSerializable(Main.EXTRA_ADDICTION) as Addiction
+        val addictionPosition = intent.extras!!.getSerializable(Main.EXTRA_ADDICTION_POSITION) as Int
+        addiction = Main.addictions[addictionPosition]
+
         updateSavedTimeDisplay()
 
         binding.btnEditTime.setOnClickListener {

--- a/app/src/main/java/com/katiearose/sobriety/activities/Timeline.kt
+++ b/app/src/main/java/com/katiearose/sobriety/activities/Timeline.kt
@@ -20,9 +20,7 @@ class Timeline : AppCompatActivity() {
         binding = ActivityTimelineBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        val addictionPosition = intent.extras!!.getSerializable(Main.EXTRA_ADDICTION_POSITION) as Int
-        val addiction = Main.addictions[addictionPosition]
-
+        val addiction = Main.addictions[intent.getIntExtra(Main.EXTRA_ADDICTION_POSITION, 0)]
         binding.timelineNotice.text = getString(R.string.showing_timeline, addiction.name)
         val adapter = TimelineAdapter(addiction, this)
         binding.timelineList.layoutManager = LinearLayoutManager(this)

--- a/app/src/main/java/com/katiearose/sobriety/activities/Timeline.kt
+++ b/app/src/main/java/com/katiearose/sobriety/activities/Timeline.kt
@@ -20,7 +20,9 @@ class Timeline : AppCompatActivity() {
         binding = ActivityTimelineBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        val addiction = intent.extras!!.getSerializable(Main.EXTRA_ADDICTION) as Addiction
+        val addictionPosition = intent.extras!!.getSerializable(Main.EXTRA_ADDICTION_POSITION) as Int
+        val addiction = Main.addictions[addictionPosition]
+
         binding.timelineNotice.text = getString(R.string.showing_timeline, addiction.name)
         val adapter = TimelineAdapter(addiction, this)
         binding.timelineList.layoutManager = LinearLayoutManager(this)


### PR DESCRIPTION
Like mentioned in the issue, putExtra passes a serialized copy of the object rather than the original. This solution works by re-adding EXTRA_ADDICTION_POSITION only for activities that require mutable access to the addiction. If it makes it cleaner, I can pass EXTRA_ADDICTION_POSITION to the Timeline activity as well, but I wasn't sure.