### PR TITLE
Add Import/Export Functionality

### DIFF
--- a/app/src/main/java/com/katiearose/sobriety/Addiction.kt
+++ b/app/src/main/java/com/katiearose/sobriety/Addiction.kt
@@ -3,6 +3,10 @@ package com.katiearose.sobriety
 import com.katiearose.sobriety.internal.CircularBuffer
 import com.katiearose.sobriety.utils.putLast
 import com.katiearose.sobriety.utils.secondsFromNow
+import com.katiearose.sobriety.utils.toJSONObject
+import com.katiearose.sobriety.utils.toLinkedHashMap
+import org.json.JSONArray
+import org.json.JSONObject
 import java.io.Serializable
 import java.time.Instant
 import java.time.LocalDate
@@ -56,6 +60,24 @@ class Addiction(
         return relapses.getAll().filterNotNull().sumOf { it } / 3L
     }
 
+    fun toJSON(): JSONObject {
+        val addictionJSON: JSONObject = JSONObject();
+        addictionJSON.put("name", name)
+        addictionJSON.put("lastRelapse", lastRelapse.toString())
+        addictionJSON.put("isStopped", isStopped)
+        addictionJSON.put("timeStopped", timeStopped)
+        addictionJSON.put("history", history.toJSONObject())
+        addictionJSON.put("priority", priority)
+        addictionJSON.put("dailyNotes", dailyNotes.toJSONObject())
+        addictionJSON.put("timeSaving", timeSaving.toString())
+        addictionJSON.put("savings", savings.toJSONObject(process_value = { pair ->
+            JSONArray(pair.toList()) as Object
+        }))
+        addictionJSON.put("milestones", milestones.toMap().toJSONObject())
+        addictionJSON.put("relapses", JSONArray(relapses.getAll()))
+        return addictionJSON
+    }
+
     fun toCacheable(): HashMap<Int, Any> {
         val map = HashMap<Int, Any>()
         map[0] = name
@@ -73,6 +95,70 @@ class Addiction(
     }
 
     companion object {
+        fun fromJSON(json: JSONObject): Addiction {
+            // Guaranteed keys
+            val name = json.getString("name")
+            val lastRelapse = Instant.parse(json.getString("lastRelapse"))
+            val isStopped = json.getBoolean("isStopped")
+            val timeStopped = json.getLong("timeStopped")
+            val history = json.getJSONObject("history").toLinkedHashMap<Long, Long>()
+            val priority = Priority.valueOf(json.getString("priority"))
+            // Reconstruct CircularBuffer with arbitrary length
+            val relapsesJSON = json.getJSONArray("relapses")
+            val relapses = CircularBuffer<Long>(relapsesJSON.length())
+            for (i in 0 until relapsesJSON.length()) {
+                if (relapsesJSON.isNull(i))
+                    continue
+                relapses.update(relapsesJSON.getLong(i))
+            }
+
+            // New Keys
+            val dailyNotes = if (json.has("dailyNotes")) {
+                json.getJSONObject("dailyNotes").toLinkedHashMap<LocalDate, String>()
+            } else LinkedHashMap()
+
+            val timeSaving = if (json.has("timeSaving")) {
+                LocalTime.parse(json.getString("timeSaving"))
+            } else LocalTime.of(0, 0)
+
+            val savings = if (json.has("savings")) {
+                json.getJSONObject("savings").toLinkedHashMap<String, Pair<Double, String>>(
+                    process_value = {obj ->
+                        val array = obj as JSONArray
+                        Pair<Double, String>(array.getDouble(0), array.getString(1))
+                    }
+                )
+            } else LinkedHashMap()
+
+            val milestones = if (json.has("milestones")) {
+                val hashmap = json.getJSONObject("milestones").toLinkedHashMap<Int, ChronoUnit>(
+                    process_value = {obj ->
+                        // ChronoUnit enum values are uppercase of toString()
+                        ChronoUnit.valueOf((obj as String).uppercase())
+                    }
+                )
+                val hashset = LinkedHashSet<Pair<Int, ChronoUnit>>()
+                for ((k, v) in hashmap) {
+                    hashset.add(Pair(k, v))
+                }
+                hashset
+            } else java.util.LinkedHashSet()
+
+            return Addiction(
+                name,
+                lastRelapse,
+                isStopped,
+                timeStopped,
+                history,
+                priority,
+                dailyNotes,
+                timeSaving,
+                savings,
+                milestones,
+                relapses
+            )
+        }
+
         fun fromCacheable(map: HashMap<Int, Any>): Addiction {
             //Migration strategies
             if (map.size == 7) { //is it version 6.1.1?

--- a/app/src/main/java/com/katiearose/sobriety/activities/Main.kt
+++ b/app/src/main/java/com/katiearose/sobriety/activities/Main.kt
@@ -75,6 +75,17 @@ class Main : AppCompatActivity() {
             }
         }
 
+    @SuppressLint("NotifyDataSetChanged")
+    private val goToSettings = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+        if (it.resultCode == RESULT_OK) {
+            if (it.data?.extras?.getBoolean("import") == true) {
+                addictions.sortWith { a1, a2 -> a1.priority.compareTo(a2.priority) }
+                cacheHandler.writeCache()
+                adapterAddictions.notifyDataSetChanged()
+            }
+        }
+    }
+
     //needed for this activity to apply md3 theme after user backs away from settings
     private val materialYouSettingListener =
         SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
@@ -276,11 +287,12 @@ class Main : AppCompatActivity() {
         return true
     }
 
+    @SuppressLint("NotifyDataSetChanged")
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         val id = item.itemId
         if (id == R.id.go_to_settings) {
             val intent = Intent(this, Settings::class.java)
-            startActivity(intent)
+            goToSettings.launch(intent)
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/app/src/main/java/com/katiearose/sobriety/activities/Settings.kt
+++ b/app/src/main/java/com/katiearose/sobriety/activities/Settings.kt
@@ -1,13 +1,20 @@
 package com.katiearose.sobriety.activities
 
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.preference.ListPreference
+import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreferenceCompat
 import com.katiearose.sobriety.R
 import com.katiearose.sobriety.utils.applyThemes
+import com.katiearose.sobriety.utils.exportData
+import com.katiearose.sobriety.utils.importData
 
 class Settings : AppCompatActivity() {
 
@@ -38,6 +45,30 @@ class Settings : AppCompatActivity() {
             val materialYouPref = findPreference<SwitchPreferenceCompat>("material_you")
             materialYouPref?.setOnPreferenceChangeListener { _, _ ->
                 requireActivity().recreate()
+                true
+            }
+
+            val getExport = registerForActivityResult(ActivityResultContracts.CreateDocument("application/json")) { uri: Uri? ->
+                if (uri != null) {
+                    context?.exportData(uri)
+                }
+            }
+            findPreference<Preference>("data_export")?.setOnPreferenceClickListener {
+                getExport.launch("sobriety_data.json")
+                true
+            }
+
+            val getImport = registerForActivityResult(ActivityResultContracts.OpenDocument()) { uri: Uri? ->
+                if (uri != null) {
+                    context?.importData(uri)
+                    val intent = Intent()
+                        .putExtra("import", true)
+                    requireActivity().setResult(Activity.RESULT_OK, intent)
+                    requireActivity().finish()
+                }
+            }
+            findPreference<Preference>("data_import")?.setOnPreferenceClickListener {
+                getImport.launch(arrayOf<String>("application/json"))
                 true
             }
         }

--- a/app/src/main/java/com/katiearose/sobriety/utils/PreferenceUtils.kt
+++ b/app/src/main/java/com/katiearose/sobriety/utils/PreferenceUtils.kt
@@ -2,7 +2,12 @@ package com.katiearose.sobriety.utils
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.net.Uri
 import androidx.preference.PreferenceManager
+import com.katiearose.sobriety.Addiction
+import com.katiearose.sobriety.activities.Main
+import org.json.JSONObject
+import java.io.BufferedReader
 
 fun Context.getSharedPref(): SharedPreferences {
     return PreferenceManager.getDefaultSharedPreferences(this)
@@ -18,4 +23,35 @@ fun SharedPreferences.getSortMilestonesPref(): String {
 
 fun SharedPreferences.getHideCompletedMilestonesPref(): Boolean {
     return getBoolean("hide_completed_milestones", false)
+}
+
+fun Context.exportData(uri: Uri) {
+    // Construct the JSON Object
+    var json: JSONObject = JSONObject();
+    for (addiction in Main.addictions) {
+        json.put(addiction.name, addiction.toJSON())
+    }
+
+    // Write to file
+    json.toString(4).byteInputStream().use { input ->
+        contentResolver.openOutputStream(uri)?.use { output ->
+            input.copyTo(output)
+        }
+    }
+}
+
+
+fun Context.importData(uri: Uri) {
+    // Read file
+    val json: JSONObject;
+    BufferedReader(contentResolver.openInputStream(uri)?.reader()).use { reader ->
+        json = JSONObject(reader.readText())
+    }
+
+    // Construct Addictions
+    for (name in json.keys()) {
+        // Don't clear existing addictions
+        Main.addictions.add(Addiction.fromJSON(json.getJSONObject(name)))
+    }
+
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,9 @@
     <string name="desc">Descending</string>
     <string name="no_sort">No sorting</string>
     <string name="hide_completed_milestones">Hide completed milestones</string>
+    <string name="data">Data</string>
+    <string name="data_export">Export</string>
+    <string name="data_import">Import</string>
     <string name="future_time_notice">You have selected a future date/time. The app will only start tracking this addiction after this time.</string>
     <string name="time_until_tracked">Will be tracked after %s</string>
     <string name="not_tracked_yet">\"%s\" has not been tracked yet. If you want to track it now, press the Relapse button.</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -55,4 +55,19 @@
 
     </PreferenceCategory>
 
+    <PreferenceCategory app:title="@string/data"
+        app:iconSpaceReserved="false">
+
+        <Preference
+            app:key="data_export"
+            app:title="@string/data_export"
+            app:iconSpaceReserved="false" />
+
+        <Preference
+            app:key="data_import"
+            app:title="@string/data_import"
+            app:iconSpaceReserved="false" />
+
+    </PreferenceCategory>
+
 </PreferenceScreen>


### PR DESCRIPTION
# Notes
- Data is stored as JSON
- On importing, existing addictions are left untouched.
- I saw that I duplicated some of the work from the [ios-port branch](https://github.com/KiARC/Sobriety/tree/ios-port), but I only saw this after I was done. Maybe this patch is easier to backport to prior versions (I am still on version v7.0.0 to avoid data loss).

I am not sure what to do with this code. Should I rebase it onto ios-port (to use the KSerializer) or keep it as is?


# Screenshot
![image](https://user-images.githubusercontent.com/120999438/211999639-43dfb0ed-1d43-45fa-bc7d-1c80e44e0c3b.png)
