### PR TITLE
Disable MissingTranslation lint for CI

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,6 +47,9 @@ android {
     buildFeatures {
         viewBinding = true
     }
+    lint {
+        disable += listOf("MissingTranslation")
+    }
     namespace = "com.katiearose.sobriety"
 }
 


### PR DESCRIPTION
This is reasonable since new strings will be added over time and we cannot expect translators to add new translations immediately.