### PR TITLE
Fix CircularBuffer serialization

### DIFF
--- a/shared/src/commonMain/kotlin/com/katiearose/sobriety/shared/CircularBuffer.kt
+++ b/shared/src/commonMain/kotlin/com/katiearose/sobriety/shared/CircularBuffer.kt
@@ -7,7 +7,7 @@ class CircularBuffer<T>(private val size: Int) {
     private val buffer: ArrayList<T?> = ArrayList(size)
 
     init {
-        for (i in 0 until size) {
+        for (i in buffer.size until size) {
             buffer.add(i, null)
         }
     }


### PR DESCRIPTION
The CircularBuffer increases by <size> number of elements every time it is imported because of this init function which doesn't consider the serialization step which initializes buffer to its previous value.

How to test original bug:
- Export an addiction (Inspect the json to see relapses buffer = [null, null, null])
- Import it
- Export it again (relapses are now:  (relapses = [null, null, null, null, null, null])