### PR TITLE
Fix offset in datepicker return value

### DIFF
--- a/app/src/main/java/com/katiearose/sobriety/activities/Create.kt
+++ b/app/src/main/java/com/katiearose/sobriety/activities/Create.kt
@@ -89,7 +89,7 @@ class Create : AppCompatActivity() {
             .build()
         datePicker.addOnPositiveButtonClickListener {
             startDateTime = ZonedDateTime.of(
-                Instant.ofEpochMilli(it).atZone(ZoneId.systemDefault()).toLocalDate(),
+                Instant.ofEpochMilli(it).atZone(ZoneId.of("UTC")).toLocalDate(),
                 startDateTime.toLocalTime(),
                 ZoneId.systemDefault()
             )

--- a/app/src/main/java/com/katiearose/sobriety/activities/DailyNotes.kt
+++ b/app/src/main/java/com/katiearose/sobriety/activities/DailyNotes.kt
@@ -68,8 +68,7 @@ class DailyNotes : AppCompatActivity() {
             dialogViewBinding.noteDate.setOnClickListener {
                 with(MaterialDatePicker.Builder.datePicker().build()) {
                     addOnPositiveButtonClickListener {
-                        pickedDate =
-                            Instant.fromEpochMilliseconds(it).toLocalDateTime(TimeZone.currentSystemDefault()).date
+                        pickedDate = Instant.fromEpochMilliseconds(it).toLocalDateTime(TimeZone.UTC).date
                         dialogViewBinding.noteDate.text = dateFormat.format(pickedDate.toJavaLocalDate())
                     }
                     show(supportFragmentManager, null)


### PR DESCRIPTION
The datepicker returns the EpochMilliseconds in UTC so we should not use the system timezone here.

Testing original bug:
1. While in a negative offset timezone from UTC, select a date (available in create addiction and create daily note menus)
2. The displayed date will be the day before.