### PR TITLE
Autofill dailyNotes if they exist

### DIFF
--- a/app/src/main/java/com/katiearose/sobriety/activities/DailyNotes.kt
+++ b/app/src/main/java/com/katiearose/sobriety/activities/DailyNotes.kt
@@ -71,6 +71,9 @@ class DailyNotes : AppCompatActivity() {
                         pickedDate =
                             Instant.fromEpochMilliseconds(it).toLocalDateTime(TimeZone.currentSystemDefault()).date
                         dialogViewBinding.noteDate.text = dateFormat.format(pickedDate.toJavaLocalDate())
+                        if (addiction.dailyNotes.contains(pickedDate)) {
+                            dialogViewBinding.noteInput.setText(addiction.dailyNotes[pickedDate])
+                        }
                     }
                     show(supportFragmentManager, null)
                 }


### PR DESCRIPTION
Since writing to a daily note of that time will overwrite the note that exists there, we should make this clear to the user.