### PR TITLE
Allow future dates in Addiction datepicker

### DIFF
--- a/app/src/main/java/com/katiearose/sobriety/activities/Create.kt
+++ b/app/src/main/java/com/katiearose/sobriety/activities/Create.kt
@@ -85,7 +85,6 @@ class Create : AppCompatActivity() {
     private fun pickDate() {
         val datePicker = MaterialDatePicker.Builder.datePicker()
             .setTitleText(R.string.pick_starting_date)
-            .setCalendarConstraints(CalendarConstraints.Builder().setEnd(System.currentTimeMillis()).build())
             .build()
         datePicker.addOnPositiveButtonClickListener {
             startDateTime = ZonedDateTime.of(


### PR DESCRIPTION
With the future tracking implemented in the app, there is no reason to constrain the datepicker to the current month.