### PR TITLE
Use plural strings to format durations

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,11 +38,11 @@ android {
     }
     compileOptions {
         isCoreLibraryDesugaringEnabled = true
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_9
+        targetCompatibility = JavaVersion.VERSION_1_9
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "9"
     }
     buildFeatures {
         viewBinding = true

--- a/app/src/main/java/com/katiearose/sobriety/activities/Savings.kt
+++ b/app/src/main/java/com/katiearose/sobriety/activities/Savings.kt
@@ -1,6 +1,5 @@
 package com.katiearose.sobriety.activities
 
-import android.annotation.SuppressLint
 import android.os.Build
 import android.os.Bundle
 import android.view.View
@@ -15,7 +14,12 @@ import com.katiearose.sobriety.databinding.ActivitySavingsBinding
 import com.katiearose.sobriety.databinding.DialogAddSavingBinding
 import com.katiearose.sobriety.shared.Addiction
 import com.katiearose.sobriety.shared.CacheHandler
-import com.katiearose.sobriety.utils.*
+import com.katiearose.sobriety.utils.applyThemes
+import com.katiearose.sobriety.utils.checkValidIntentData
+import com.katiearose.sobriety.utils.isInputEmpty
+import com.katiearose.sobriety.utils.showConfirmDialog
+import com.katiearose.sobriety.utils.toggleVisibility
+import com.katiearose.sobriety.utils.write
 import kotlinx.datetime.LocalTime
 
 class Savings : AppCompatActivity() {
@@ -141,14 +145,12 @@ class Savings : AppCompatActivity() {
         adapter.update()
     }
 
-    @SuppressLint("StringFormatMatches")
     private fun updateSavedTimeDisplay() {
         binding.timeSaved.text =
             if (addiction.timeSaving.hour == 0 && addiction.timeSaving.minute == 0) getString(R.string.no_set)
-            else getString(
-                R.string.hours_minutes,
-                addiction.timeSaving.hour,
-                addiction.timeSaving.minute
-            )
+            else StringBuilder(resources.getQuantityString(R.plurals.hours, addiction.timeSaving.hour, addiction.timeSaving.hour))
+                .append(" ")
+                .append(resources.getQuantityString(R.plurals.minutes, addiction.timeSaving.minute, addiction.timeSaving.minute))
+                .apply { deleteAt(length - 1) } //delete the comma at the end
     }
 }

--- a/app/src/main/java/com/katiearose/sobriety/utils/Utils.kt
+++ b/app/src/main/java/com/katiearose/sobriety/utils/Utils.kt
@@ -46,16 +46,16 @@ fun Context.convertSecondsToString(given: Long): String {
     time -= mo * MONTH
     val y = time / YEAR
     val stringBuilder = StringBuilder()
-    if (y != 0L) stringBuilder.append(getString(R.string.years, y)).append(" ")
-    if (mo != 0L) stringBuilder.append(getString(R.string.months, mo)).append(" ")
-    if (w != 0L) stringBuilder.append(getString(R.string.weeks, w)).append(" ")
-    if (d != 0L) stringBuilder.append(getString(R.string.days, d)).append(" ")
-    if (h != 0L) stringBuilder.append(getString(R.string.hours, h)).append(" ")
-    if (m != 0L) stringBuilder.append(getString(R.string.minutes, m)).append(" ")
+    if (y != 0L) stringBuilder.append(resources.getQuantityString(R.plurals.years, y.toInt(), y)).append(" ")
+    if (mo != 0L) stringBuilder.append(resources.getQuantityString(R.plurals.months, mo.toInt(), mo)).append(" ")
+    if (w != 0L) stringBuilder.append(resources.getQuantityString(R.plurals.weeks, w.toInt(), w)).append(" ")
+    if (d != 0L) stringBuilder.append(resources.getQuantityString(R.plurals.days, d.toInt(), d)).append(" ")
+    if (h != 0L) stringBuilder.append(resources.getQuantityString(R.plurals.hours, h.toInt(), h)).append(" ")
+    if (m != 0L) stringBuilder.append(resources.getQuantityString(R.plurals.minutes, m.toInt(), m)).append(" ")
     if (!(y == 0L && mo == 0L && w == 0L && d == 0L && h == 0L && m == 0L)) stringBuilder.append(
         getString(R.string.and)
     ).append(" ")
-    stringBuilder.append(getString(R.string.seconds, s))
+    stringBuilder.append(resources.getQuantityString(R.plurals.seconds, s.toInt(), s))
     return stringBuilder.toString()
 }
 
@@ -80,16 +80,16 @@ fun Context.convertRangeToString(start: Long, end: Long = Instant.now().toEpochM
     val s = duration.toSecondsPart()
 
     val stringBuilder = StringBuilder()
-    if (y != 0) stringBuilder.append(getString(R.string.years, y)).append(" ")
-    if (mo != 0) stringBuilder.append(getString(R.string.months, mo)).append(" ")
-    if (w != 0) stringBuilder.append(getString(R.string.weeks, w)).append(" ")
-    if (d != 0) stringBuilder.append(getString(R.string.days, d)).append(" ")
-    if (h != 0) stringBuilder.append(getString(R.string.hours, h)).append(" ")
-    if (m != 0) stringBuilder.append(getString(R.string.minutes, m)).append(" ")
+    if (y != 0) stringBuilder.append(resources.getQuantityString(R.plurals.years, y, y)).append(" ")
+    if (mo != 0) stringBuilder.append(resources.getQuantityString(R.plurals.months, mo, mo)).append(" ")
+    if (w != 0) stringBuilder.append(resources.getQuantityString(R.plurals.weeks, w, w)).append(" ")
+    if (d != 0) stringBuilder.append(resources.getQuantityString(R.plurals.days, d, d)).append(" ")
+    if (h != 0) stringBuilder.append(resources.getQuantityString(R.plurals.hours, h, h)).append(" ")
+    if (m != 0) stringBuilder.append(resources.getQuantityString(R.plurals.minutes, m, m)).append(" ")
     if (!(y == 0 && mo == 0 && w == 0 && d == 0 && h == 0 && m == 0)) stringBuilder.append(
         getString(R.string.and)
     ).append(" ")
-    stringBuilder.append(getString(R.string.seconds, s))
+    stringBuilder.append(resources.getQuantityString(R.plurals.seconds, s, s))
     return stringBuilder.toString()
 }
 

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -17,14 +17,7 @@
     <string name="create">Oluştur</string>
     <string name="error_empty_name">İsim alanı boş</string>
     <string name="error_duplicate_entry">Yinelenen girişler oluşturulamıyor</string>
-    <string name="years">%d Yıl,</string>
-    <string name="months">%d Ay,</string>
-    <string name="weeks">%d Hafta,</string>
-    <string name="days">%d Gün,</string>
-    <string name="hours">%d Saat,</string>
-    <string name="minutes">%d Dakika,</string>
     <string name="and">Ve</string>
-    <string name="seconds">%d Saniye</string>
     <string name="recent_avg">Son ortalama: %s</string>
     <string name="delete">Sil</string>
     <string name="delete_confirm">Girişi gerçekten silmek istiyor musunuz? \"%s\"?\nBu işlem geri alınamaz.</string>
@@ -72,7 +65,6 @@
     <string name="savings">Tasarruf</string>
     <string name="time_saved_per_day">Günlük tasarruf süresi</string>
     <string name="select_time_saved">Kaydedilen süreyi seçin</string>
-    <string name="hours_minutes">%d saat, %d dakika</string>
     <string name="no_set">Ayarlanmadı</string>
     <string name="other_savings">Diğer tasarruflar</string>
     <string name="add_new_saving">Yeni tasarruf ekle</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,14 +17,35 @@
     <string name="create">Create</string>
     <string name="error_empty_name">Name is empty</string>
     <string name="error_duplicate_entry">Can\'t create duplicate entries</string>
-    <string name="years">%d years,</string>
-    <string name="months">%d months,</string>
-    <string name="weeks">%d weeks,</string>
-    <string name="days">%d days,</string>
-    <string name="hours">%d hours,</string>
-    <string name="minutes">%d minutes,</string>
+    <plurals name="years">
+        <item quantity="one">%d year,</item>
+        <item quantity="other">%d years,</item>
+    </plurals>
+    <plurals name="months">
+        <item quantity="one">%d month,</item>
+        <item quantity="other">%d months,</item>
+    </plurals>
+    <plurals name="weeks">
+        <item quantity="one">%d week,</item>
+        <item quantity="other">%d weeks,</item>
+    </plurals>
+    <plurals name="days">
+        <item quantity="one">%d day,</item>
+        <item quantity="other">%d days,</item>
+    </plurals>
+    <plurals name="hours">
+        <item quantity="one">%d hour,</item>
+        <item quantity="other">%d hours,</item>
+    </plurals>
+    <plurals name="minutes">
+        <item quantity="one">%d minute,</item>
+        <item quantity="other">%d minutes,</item>
+    </plurals>
     <string name="and">and</string>
-    <string name="seconds">%d seconds</string>
+    <plurals name="seconds">
+        <item quantity="one">%d second</item>
+        <item quantity="other">%d seconds</item>
+    </plurals>
     <string name="recent_avg">Recent Average: %s</string>
     <string name="delete">Delete</string>
     <string name="delete_confirm">Do you really want to delete entry \"%s\"?\nThis action cannot be undone.</string>
@@ -72,7 +93,6 @@
     <string name="savings">Savings</string>
     <string name="time_saved_per_day">Time saved per day</string>
     <string name="select_time_saved">Select amount of time saved</string>
-    <string name="hours_minutes" tools:ignore="StringFormatMatches">%d hours, %d minutes</string>
     <string name="no_set">Not set</string>
     <string name="other_savings">Other savings</string>
     <string name="add_new_saving">Add new saving</string>


### PR DESCRIPTION
Time units now use proper plural/singular forms instead of hardcoded word. No more "1 hours"!

Also, since `Duration.toXYZPart()` require JDK 9+ I bumped it. The usual build process uses JDK 11 anyway, so it doesn't really affect anything.