### PR TITLE
Update badges on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Feel free to contact me about any issues, suggestions or comments you have about
 
 # Repository Metadata (via Shields.io)
 ## Core
-![GitHub](https://img.shields.io/github/license/KiARC/Sobriety?style=for-the-badge)
-![GitHub Workflow Status](https://img.shields.io/github/workflow/status/KiARC/Sobriety/Android%20CI?label=CI&style=for-the-badge)
-![Maintenance](https://img.shields.io/maintenance/yes/2022?style=for-the-badge)
+![GitHub](https://img.shields.io/github/license/KiARC/Sobriety?style=for-the-badge&color=success)
+![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/KiARC/Sobriety/ci.yml?branch=master&style=for-the-badge)
+![Maintenance](https://img.shields.io/maintenance/yes/2023?style=for-the-badge)
 ## Size
 ![GitHub code size](https://img.shields.io/github/languages/code-size/KiARC/Sobriety?style=for-the-badge)
 ![GitHub repo size](https://img.shields.io/github/repo-size/KiARC/Sobriety?style=for-the-badge)
@@ -40,7 +40,7 @@ Feel free to contact me about any issues, suggestions or comments you have about
 
 ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/KiARC/Sobriety?label=Latest%20Release&sort=semver&style=for-the-badge)
 ![GitHub Release Date](https://img.shields.io/github/release-date/KiARC/Sobriety?label=Latest%20Release%20Date&style=for-the-badge&sort=semver)
-![IzzyOnDroid](https://img.shields.io/endpoint?url=https://apt.izzysoft.de/fdroid/api/v1/shield/com.katiearose.sobriety&label=IzzyOnDroid&style=for-the-badge)
+![F-Droid](https://img.shields.io/f-droid/v/com.katiearose.sobriety?style=for-the-badge)
 ## Issue Counts
 ![GitHub open issues](https://img.shields.io/github/issues-raw/KiARC/Sobriety?style=for-the-badge)
 ![GitHub closed issues](https://img.shields.io/github/issues-closed-raw/KiARC/Sobriety?style=for-the-badge)

--- a/README.md
+++ b/README.md
@@ -28,28 +28,28 @@ Feel free to contact me about any issues, suggestions or comments you have about
 
 # Repository Metadata (via Shields.io)
 ## Core
-![GitHub](https://img.shields.io/github/license/KiARC/Sobriety?style=for-the-badge?)
-![GitHub Workflow Status](https://img.shields.io/github/workflow/status/KiARC/Sobriety/Android%20CI?label=CI&style=for-the-badge?)
-![Maintenance](https://img.shields.io/maintenance/yes/2022?style=for-the-badge?)
+![GitHub](https://img.shields.io/github/license/KiARC/Sobriety?style=for-the-badge)
+![GitHub Workflow Status](https://img.shields.io/github/workflow/status/KiARC/Sobriety/Android%20CI?label=CI&style=for-the-badge)
+![Maintenance](https://img.shields.io/maintenance/yes/2022?style=for-the-badge)
 ## Size
-![GitHub code size](https://img.shields.io/github/languages/code-size/KiARC/Sobriety?style=for-the-badge?)
-![GitHub repo size](https://img.shields.io/github/repo-size/KiARC/Sobriety?style=for-the-badge?)
+![GitHub code size](https://img.shields.io/github/languages/code-size/KiARC/Sobriety?style=for-the-badge)
+![GitHub repo size](https://img.shields.io/github/repo-size/KiARC/Sobriety?style=for-the-badge)
 ## Release Info
 ![GitHub all releases](https://img.shields.io/github/downloads/KiARC/Sobriety/total?style=for-the-badge&label=Downloads%20%28All%20Releases%29?)
 ![GitHub downloads by release (latest by date)](https://img.shields.io/github/downloads/KiARC/Sobriety/latest/total?style=for-the-badge&label=Downloads%20%28Latest%20Release%29?)
 
-![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/KiARC/Sobriety?label=Latest%20Release&sort=semver&style=for-the-badge?)
-![GitHub Release Date](https://img.shields.io/github/release-date/KiARC/Sobriety?label=Latest%20Release%20Date&style=for-the-badge&sort=semver?)
-![IzzyOnDroid](https://img.shields.io/endpoint?url=https://apt.izzysoft.de/fdroid/api/v1/shield/com.katiearose.sobriety&label=IzzyOnDroid&style=for-the-badge?)
+![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/KiARC/Sobriety?label=Latest%20Release&sort=semver&style=for-the-badge)
+![GitHub Release Date](https://img.shields.io/github/release-date/KiARC/Sobriety?label=Latest%20Release%20Date&style=for-the-badge&sort=semver)
+![IzzyOnDroid](https://img.shields.io/endpoint?url=https://apt.izzysoft.de/fdroid/api/v1/shield/com.katiearose.sobriety&label=IzzyOnDroid&style=for-the-badge)
 ## Issue Counts
-![GitHub open issues](https://img.shields.io/github/issues-raw/KiARC/Sobriety?style=for-the-badge?)
-![GitHub closed issues](https://img.shields.io/github/issues-closed-raw/KiARC/Sobriety?style=for-the-badge?)
+![GitHub open issues](https://img.shields.io/github/issues-raw/KiARC/Sobriety?style=for-the-badge)
+![GitHub closed issues](https://img.shields.io/github/issues-closed-raw/KiARC/Sobriety?style=for-the-badge)
 ## PR Counts
-![GitHub open pull requests](https://img.shields.io/github/issues-pr-raw/KiARC/Sobriety?style=for-the-badge?)
-![GitHub closed pull requests](https://img.shields.io/github/issues-pr-closed-raw/KiARC/Sobriety?style=for-the-badge?)
+![GitHub open pull requests](https://img.shields.io/github/issues-pr-raw/KiARC/Sobriety?style=for-the-badge)
+![GitHub closed pull requests](https://img.shields.io/github/issues-pr-closed-raw/KiARC/Sobriety?style=for-the-badge)
 ## Stats
-![GitHub commit activity](https://img.shields.io/github/commit-activity/w/KiARC/Sobriety?style=for-the-badge?)
-![GitHub commits since latest release (by date)](https://img.shields.io/github/commits-since/KiARC/Sobriety/latest?style=for-the-badge?)
+![GitHub commit activity](https://img.shields.io/github/commit-activity/w/KiARC/Sobriety?style=for-the-badge)
+![GitHub commits since latest release (by date)](https://img.shields.io/github/commits-since/KiARC/Sobriety/latest?style=for-the-badge)
 
-![GitHub contributors](https://img.shields.io/github/contributors/KiARC/Sobriety?style=for-the-badge?)
-![GitHub Discussions](https://img.shields.io/github/discussions/KiARC/Sobriety?style=for-the-badge?)
+![GitHub contributors](https://img.shields.io/github/contributors/KiARC/Sobriety?style=for-the-badge)
+![GitHub Discussions](https://img.shields.io/github/discussions/KiARC/Sobriety?style=for-the-badge)

--- a/README.md
+++ b/README.md
@@ -28,28 +28,28 @@ Feel free to contact me about any issues, suggestions or comments you have about
 
 # Repository Metadata (via Shields.io)
 ## Core
-![GitHub](https://img.shields.io/github/license/KiARC/Sobriety?style=for-the-badge&color=success)
-![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/KiARC/Sobriety/ci.yml?branch=master&style=for-the-badge)
-![Maintenance](https://img.shields.io/maintenance/yes/2023?style=for-the-badge)
+[![License](https://img.shields.io/github/license/KiARC/Sobriety?style=for-the-badge&color=success)](https://www.gnu.org/licenses/gpl-3.0.html)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/KiARC/Sobriety/ci.yml?branch=master&style=for-the-badge)](https://github.com/KiARC/Sobriety/actions/workflows/ci.yml?query=branch%3Amaster)
+[![Maintenance](https://img.shields.io/maintenance/yes/2023?style=for-the-badge)](https://github.com/KiARC/Sobriety)
 ## Size
-![GitHub code size](https://img.shields.io/github/languages/code-size/KiARC/Sobriety?style=for-the-badge)
-![GitHub repo size](https://img.shields.io/github/repo-size/KiARC/Sobriety?style=for-the-badge)
+[![GitHub code size](https://img.shields.io/github/languages/code-size/KiARC/Sobriety?style=for-the-badge)](https://github.com/KiARC/Sobriety)
+[![GitHub repo size](https://img.shields.io/github/repo-size/KiARC/Sobriety?style=for-the-badge)](https://github.com/KiARC/Sobriety)
 ## Release Info
-![GitHub all releases](https://img.shields.io/github/downloads/KiARC/Sobriety/total?style=for-the-badge&label=Downloads%20%28All%20Releases%29?)
-![GitHub downloads by release (latest by date)](https://img.shields.io/github/downloads/KiARC/Sobriety/latest/total?style=for-the-badge&label=Downloads%20%28Latest%20Release%29?)
+[![GitHub all releases](https://img.shields.io/github/downloads/KiARC/Sobriety/total?style=for-the-badge&label=Downloads%20%28All%20Releases%29?)](https://github.com/KiARC/Sobriety/releases)
+[![GitHub downloads by release (latest by date)](https://img.shields.io/github/downloads/KiARC/Sobriety/latest/total?style=for-the-badge&label=Downloads%20%28Latest%20Release%29?)](https://github.com/KiARC/Sobriety/releases/latest)
 
-![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/KiARC/Sobriety?label=Latest%20Release&sort=semver&style=for-the-badge)
-![GitHub Release Date](https://img.shields.io/github/release-date/KiARC/Sobriety?label=Latest%20Release%20Date&style=for-the-badge&sort=semver)
-![F-Droid](https://img.shields.io/f-droid/v/com.katiearose.sobriety?style=for-the-badge)
+[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/KiARC/Sobriety?label=Latest%20Release&sort=semver&style=for-the-badge)](https://github.com/KiARC/Sobriety/releases/latest)
+[![GitHub Release Date](https://img.shields.io/github/release-date/KiARC/Sobriety?label=Latest%20Release%20Date&style=for-the-badge&sort=semver)](https://github.com/KiARC/Sobriety/releases/latest)
+[![F-Droid](https://img.shields.io/f-droid/v/com.katiearose.sobriety?style=for-the-badge)](https://f-droid.org/en/packages/com.katiearose.sobriety/)
 ## Issue Counts
-![GitHub open issues](https://img.shields.io/github/issues-raw/KiARC/Sobriety?style=for-the-badge)
-![GitHub closed issues](https://img.shields.io/github/issues-closed-raw/KiARC/Sobriety?style=for-the-badge)
+[![GitHub open issues](https://img.shields.io/github/issues-raw/KiARC/Sobriety?style=for-the-badge)](https://github.com/KiARC/Sobriety/issues)
+[![GitHub closed issues](https://img.shields.io/github/issues-closed-raw/KiARC/Sobriety?style=for-the-badge)](https://github.com/KiARC/Sobriety/issues?q=is%3Aissue+is%3Aclosed)
 ## PR Counts
-![GitHub open pull requests](https://img.shields.io/github/issues-pr-raw/KiARC/Sobriety?style=for-the-badge)
-![GitHub closed pull requests](https://img.shields.io/github/issues-pr-closed-raw/KiARC/Sobriety?style=for-the-badge)
+[![GitHub open pull requests](https://img.shields.io/github/issues-pr-raw/KiARC/Sobriety?style=for-the-badge)](https://github.com/KiARC/Sobriety/pulls)
+[![GitHub closed pull requests](https://img.shields.io/github/issues-pr-closed-raw/KiARC/Sobriety?style=for-the-badge)](https://github.com/KiARC/Sobriety/pulls?q=is%3Apr+is%3Aclosed)
 ## Stats
-![GitHub commit activity](https://img.shields.io/github/commit-activity/w/KiARC/Sobriety?style=for-the-badge)
-![GitHub commits since latest release (by date)](https://img.shields.io/github/commits-since/KiARC/Sobriety/latest?style=for-the-badge)
+[![GitHub commit activity](https://img.shields.io/github/commit-activity/w/KiARC/Sobriety?style=for-the-badge)](https://github.com/KiARC/Sobriety/graphs/commit-activity)
+[![GitHub commits since latest release (by date)](https://img.shields.io/github/commits-since/KiARC/Sobriety/latest?style=for-the-badge)](https://github.com/KiARC/Sobriety/graphs/commit-activity)
 
-![GitHub contributors](https://img.shields.io/github/contributors/KiARC/Sobriety?style=for-the-badge)
-![GitHub Discussions](https://img.shields.io/github/discussions/KiARC/Sobriety?style=for-the-badge)
+[![GitHub contributors](https://img.shields.io/github/contributors/KiARC/Sobriety?style=for-the-badge)](https://github.com/KiARC/Sobriety/graphs/contributors)
+[![GitHub Discussions](https://img.shields.io/github/discussions/KiARC/Sobriety?style=for-the-badge)](https://github.com/KiARC/Sobriety/discussions)


### PR DESCRIPTION
[Current README](https://github.com/KiARC/Sobriety/blob/master/README.md#repository-metadata-via-shieldsio)
[New README.md](https://github.com/cubandle/Sobriety/blob/readme/README.md#repository-metadata-via-shieldsio)
- Use unified badge style (for-the-badge)
- Update CI badge (See [issue](https://github.com/badges/shields/issues/8671))
- Replace IzzyOnDroid badge with F-Droid badge
- Update to current year in maintenance badge
- Add links to the shields. Some of the links are a little redundant, but I think it's better than linking the image itself.