### PR TITLE
Add new Summary activity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -50,6 +50,14 @@
                 android:value="" />
         </activity>
         <activity
+            android:name=".activities.Summary"
+            android:exported="false"
+            android:label="@string/summary">
+            <meta-data
+                android:name="android.app.lib_name"
+                android:value="" />
+        </activity>
+        <activity
             android:name=".activities.Create"
             android:exported="false"
             android:label="@string/add_new_addiction">

--- a/app/src/main/java/com/katiearose/sobriety/AddictionCardAdapter.kt
+++ b/app/src/main/java/com/katiearose/sobriety/AddictionCardAdapter.kt
@@ -29,7 +29,8 @@ class AddictionCardAdapter(
     private val stopButtonAction: (Addiction) -> Unit,
     private val timelineButtonAction: (Addiction) -> Unit,
     private val priorityTextViewAction: (Addiction) -> Unit,
-    private val miscButtonAction: (Addiction) -> Unit
+    private val miscButtonAction: (Addiction) -> Unit,
+    private val cardButtonAction: (Addiction) -> Unit
 ) :
     RecyclerView.Adapter<AddictionCardAdapter.AddictionCardViewHolder>() {
 
@@ -46,6 +47,7 @@ class AddictionCardAdapter(
             { timelineButtonAction(Main.addictions[it]) },
             { priorityTextViewAction(Main.addictions[it]) },
             { miscButtonAction(Main.addictions[it]) },
+            { cardButtonAction(Main.addictions[it]) },
             { Main.addictions[it] })
     }
 
@@ -106,6 +108,7 @@ class AddictionCardAdapter(
         timelineButtonAction: (Int) -> Unit,
         priorityTextViewAction: (Int) -> Unit,
         miscButtonAction: (Int) -> Unit,
+        cardButtonAction: (Int) -> Unit,
         private val addictionSupplier: (Int) -> Addiction) : RecyclerView.ViewHolder(binding.root) {
         val textViewName: TextView = binding.textViewAddictionName
         val textViewPriority: TextView = binding.textViewPriority
@@ -154,6 +157,7 @@ class AddictionCardAdapter(
             binding.imageTimeline.setOnClickListener { timelineButtonAction(adapterPosition) }
             textViewPriority.setOnClickListener { priorityTextViewAction(adapterPosition) }
             binding.imageMisc.setOnClickListener { miscButtonAction(adapterPosition) }
+            binding.cardViewAddiction.setOnClickListener { cardButtonAction(adapterPosition) }
         }
     }
 }

--- a/app/src/main/java/com/katiearose/sobriety/ProgressBarAdapter.kt
+++ b/app/src/main/java/com/katiearose/sobriety/ProgressBarAdapter.kt
@@ -1,0 +1,76 @@
+package com.katiearose.sobriety
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView.ViewHolder
+import com.katiearose.sobriety.databinding.ListItemProgressBarBinding
+import com.katiearose.sobriety.shared.Addiction
+import com.katiearose.sobriety.utils.convertRangeToPercentList
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.datetime.DateTimeUnit
+
+class ProgressBarAdapter(
+    private val addiction: Addiction, private val context: Context,
+) :
+    ListAdapter<Triple<Int, Int, DateTimeUnit>, ProgressBarAdapter.ProgressBarViewHolder>(object :
+        DiffUtil.ItemCallback<Triple<Int, Int, DateTimeUnit>>() {
+        override fun areItemsTheSame(
+            oldItem: Triple<Int, Int, DateTimeUnit>,
+            newItem: Triple<Int, Int, DateTimeUnit>
+        ): Boolean = oldItem.third == newItem.third
+
+        override fun areContentsTheSame(
+            oldItem: Triple<Int, Int, DateTimeUnit>,
+            newItem: Triple<Int, Int, DateTimeUnit>
+        ): Boolean = oldItem.first == newItem.first
+    }) {
+
+    init {
+        update()
+        MainScope().launch {
+            while (true) {
+                update()
+                delay(1000)
+            }
+        }
+    }
+
+    fun update() {
+        val list = convertRangeToPercentList(addiction.history.keys.last())
+        // Filter initial zeros
+        submitList(list.subList(list.indexOfFirst { it.first != 0 }, list.size))
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ProgressBarViewHolder {
+        val binding =
+            ListItemProgressBarBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return ProgressBarViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: ProgressBarViewHolder, position: Int) {
+        val bar = currentList[position]
+        holder.timeUnitProgress.progress = bar.second
+        holder.timeUnit.text = when (bar.third) {
+            DateTimeUnit.SECOND ->  context.resources.getQuantityString(R.plurals.seconds, bar.first, bar.first)
+            DateTimeUnit.MINUTE -> context.resources.getQuantityString(R.plurals.minutes, bar.first, bar.first)
+            DateTimeUnit.HOUR -> context.resources.getQuantityString(R.plurals.hours, bar.first, bar.first)
+            DateTimeUnit.DAY -> context.resources.getQuantityString(R.plurals.days, bar.first, bar.first)
+            DateTimeUnit.MONTH -> context.resources.getQuantityString(R.plurals.months, bar.first, bar.first)
+            DateTimeUnit.YEAR -> context.resources.getQuantityString(R.plurals.years, bar.first, bar.first)
+            else -> "Unsupported"
+        }
+    }
+
+    class ProgressBarViewHolder(
+        binding: ListItemProgressBarBinding,
+    ) :
+        ViewHolder(binding.root) {
+        val timeUnit = binding.timeUnit
+        val timeUnitProgress = binding.timeUnitProgress
+    }
+}

--- a/app/src/main/java/com/katiearose/sobriety/activities/Main.kt
+++ b/app/src/main/java/com/katiearose/sobriety/activities/Main.kt
@@ -239,10 +239,21 @@ class Main : AppCompatActivity() {
             dialog.setContentView(dialogViewBinding.root)
             dialog.show()
         }, cardButtonAction = {
-            startActivity(
-                Intent(this@Main, Summary::class.java)
-                    .putExtra(EXTRA_ADDICTION_POSITION, addictions.indexOf(it))
-            )
+            when(it.status) {
+                Addiction.Status.Ongoing, Addiction.Status.Stopped ->
+                    startActivity(
+                        Intent(this@Main, Summary::class.java)
+                            .putExtra(EXTRA_ADDICTION_POSITION, addictions.indexOf(it))
+                    )
+
+                Addiction.Status.Future ->
+                    Snackbar.make(
+                        binding.root,
+                        getString(R.string.not_tracked_yet, it.name),
+                        BaseTransientBottomBar.LENGTH_SHORT
+                    ).show()
+            }
+
         })
         binding.recyclerAddictions.layoutManager = LinearLayoutManager(this)
         binding.recyclerAddictions.adapter = adapterAddictions

--- a/app/src/main/java/com/katiearose/sobriety/activities/Main.kt
+++ b/app/src/main/java/com/katiearose/sobriety/activities/Main.kt
@@ -238,6 +238,11 @@ class Main : AppCompatActivity() {
             }
             dialog.setContentView(dialogViewBinding.root)
             dialog.show()
+        }, cardButtonAction = {
+            startActivity(
+                Intent(this@Main, Summary::class.java)
+                    .putExtra(EXTRA_ADDICTION_POSITION, addictions.indexOf(it))
+            )
         })
         binding.recyclerAddictions.layoutManager = LinearLayoutManager(this)
         binding.recyclerAddictions.adapter = adapterAddictions

--- a/app/src/main/java/com/katiearose/sobriety/activities/Summary.kt
+++ b/app/src/main/java/com/katiearose/sobriety/activities/Summary.kt
@@ -1,0 +1,38 @@
+package com.katiearose.sobriety.activities
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.SimpleItemAnimator
+import com.katiearose.sobriety.ProgressBarAdapter
+import com.katiearose.sobriety.databinding.ActivitySummaryBinding
+import com.katiearose.sobriety.shared.Addiction
+import com.katiearose.sobriety.utils.*
+
+class Summary : AppCompatActivity() {
+
+    private lateinit var binding: ActivitySummaryBinding
+    private lateinit var addiction: Addiction
+    private lateinit var progressAdapter: ProgressBarAdapter
+
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        applyThemes()
+        super.onCreate(savedInstanceState)
+        binding = ActivitySummaryBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        addiction = Main.addictions[checkValidIntentData()]
+        title = addiction.name
+
+
+        progressAdapter = ProgressBarAdapter(addiction, this)
+        binding.progressBarList.layoutManager = LinearLayoutManager(this)
+        binding.progressBarList.setHasFixedSize(true)
+        binding.progressBarList.adapter = progressAdapter
+        (binding.progressBarList.itemAnimator as SimpleItemAnimator).supportsChangeAnimations = false
+    }
+
+    private fun update() {
+        progressAdapter.update()
+    }
+}

--- a/app/src/main/java/com/katiearose/sobriety/utils/Utils.kt
+++ b/app/src/main/java/com/katiearose/sobriety/utils/Utils.kt
@@ -66,10 +66,16 @@ fun Context.convertRangeToString(start: Long, end: Long = Instant.now().toEpochM
         TimeZone.getDefault().toZoneId())
     val endDate: LocalDateTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(end),
         TimeZone.getDefault().toZoneId())
-    // Period for years, months, weeks, days
-    val period: Period = Period.between(startDate.toLocalDate(), endDate.toLocalDate())
-    // Duration for hours, minutes, seconds
+    // Duration calculated time based days rather than "conceptual" days
+    // Used directly for hours, minutes, seconds
     val duration: Duration = Duration.between(startDate, endDate)
+    // Period for years, months, weeks, days
+    val period: Period = Period.between(
+        // The reason why startDate is not used is to prevent a conceptual calculation of days
+        // i.e. 2023-01-30T23:30 to 2023-01-31TT01:30 is 1 conceptual day but only 2 literal hours
+        endDate.minusDays(duration.toDaysPart()).toLocalDate(),
+        endDate.toLocalDate()
+    )
 
     val y = period.years
     val mo = period.months

--- a/app/src/main/java/com/katiearose/sobriety/utils/Utils.kt
+++ b/app/src/main/java/com/katiearose/sobriety/utils/Utils.kt
@@ -3,18 +3,17 @@ package com.katiearose.sobriety.utils
 import android.app.Activity
 import android.content.Context
 import android.view.View
-import android.view.ViewGroup
 import android.widget.TextView
 import android.widget.Toast
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.widget.AppCompatEditText
 import androidx.preference.PreferenceManager
-import androidx.viewbinding.ViewBinding
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.katiearose.sobriety.R
 import com.katiearose.sobriety.activities.Main
 import com.katiearose.sobriety.shared.CacheHandler
+import kotlinx.datetime.DateTimeUnit
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalDateTime
@@ -97,6 +96,48 @@ fun Context.convertRangeToString(start: Long, end: Long = Instant.now().toEpochM
     ).append(" ")
     stringBuilder.append(resources.getQuantityString(R.plurals.seconds, s, s))
     return stringBuilder.toString()
+}
+
+// Each triple contains the raw number (e.g. 12), the percentage in per mille (500), and the unit (hours)
+fun convertRangeToPercentList(start: Long, end: Long = Instant.now().toEpochMilli())
+        : List<Triple<Int, Int, DateTimeUnit>> {
+    val startDate: LocalDateTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(start),
+        TimeZone.getDefault().toZoneId())
+    val endDate: LocalDateTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(end),
+        TimeZone.getDefault().toZoneId())
+    // Duration calculated time based days rather than "conceptual" days
+    // Used directly for hours, minutes, seconds
+    val duration: Duration = Duration.between(startDate, endDate)
+    // Period for years, months, weeks, days
+    val period: Period = Period.between(
+        // The reason why startDate is not used is to prevent a conceptual calculation of days
+        // i.e. 2023-01-30T23:30 to 2023-01-31TT01:30 is 1 conceptual day but only 2 literal hours
+        endDate.minusDays(duration.toDaysPart()).toLocalDate(),
+        endDate.toLocalDate()
+    )
+
+    // Calculate the number of days until the month period ends
+    val nextMonth = startDate.plus(Period.of(period.years, period.months + 1, 0))
+    val durationLeft = Duration.between(endDate, nextMonth)
+    val daysLeft = (duration.plus(durationLeft).toDaysPart() - duration.toDaysPart()).toInt()
+
+    // Initially store denominator in second part of triple
+    return listOf(
+        // Years progress bar should never complete, but crosses 50% at 2 years
+        Triple(period.years, period.years+2, DateTimeUnit.YEAR),
+        Triple(period.months, 12, DateTimeUnit.MONTH),
+        // Weeks make the visualization non-whole so they are omitted
+        Triple(period.days, period.days + daysLeft, DateTimeUnit.DAY),
+        Triple(duration.toHoursPart(), 24, DateTimeUnit.HOUR),
+        Triple(duration.toMinutesPart(), 60, DateTimeUnit.MINUTE),
+        Triple(duration.toSecondsPart(), 60, DateTimeUnit.SECOND)
+    ).map {
+        Triple(
+            it.first,
+            (1000 * it.first.toDouble().div(it.second)).toInt(),
+            it.third
+        )
+    }
 }
 
 fun Context.showConfirmDialog(title: String, message: String, action: () -> Unit) {

--- a/app/src/main/res/layout/activity_summary.xml
+++ b/app/src/main/res/layout/activity_summary.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".activities.Summary">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/progress_bar_list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+
+</RelativeLayout>

--- a/app/src/main/res/layout/list_item_progress_bar.xml
+++ b/app/src/main/res/layout/list_item_progress_bar.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="10dp">
+
+        <com.google.android.material.progressindicator.LinearProgressIndicator
+            android:id="@+id/time_unit_progress"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginTop="3dp"
+            android:max="1000"
+            app:trackThickness="50dp"
+            app:trackCornerRadius="5dp"
+            app:indicatorDirectionLinear="startToEnd"/>
+
+        <TextView
+            android:id="@+id/time_unit"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignTop="@id/time_unit_progress"
+            android:layout_alignBottom="@id/time_unit_progress"
+            android:layout_alignStart="@id/time_unit_progress"
+            android:layout_marginStart="10dp"
+            android:gravity="center_vertical"
+            android:textSize="@dimen/text_size_medium"
+            android:textStyle="bold"/>
+
+
+</RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -133,4 +133,5 @@
     <string name="data_export">Export</string>
     <string name="data_import">Import</string>
     <string name="average_attempts_window_pref">Number of Relapses (0 to disable)</string>
+    <string name="summary">Summary</string>
 </resources>


### PR DESCRIPTION
# Notes
Hello, I hope everyone is doing well! This is a new activity that shows a more visual representation of the current progress on the addiction. It is only reachable on ongoing and stopped addictions.

The reason why the title of the activity is set to the name of the addiction is because I think this activity can be extended to include more information than these progress bars in the future (e.g. graphs?). I think the options here are: "[Name] Summary", "Summary", or "[Name]". Let me know which one you prefer.

I had to remove the weeks from the visualization because of the ambiguity: if a month is composed of 31 days, should the days progress bar have a maximum of 7 days until the fifth week where the max is 3? Should the weeks progress bar have a maximum of 4 or 5 weeks depending on the length of the month? it seemed a little weird to me so I decided not to include it all, but let me know what you think about this.

The years progress bar never reaches 100%. Instead, it is calculated by years / (years+2) which seemed like a good number to me.

The first commit in this PR fixes an unrelated bug where the current relapse duration is off by 1 day, see that commit message + content for details.

# Questions
- I am terrible at styling, so I was wondering if you had any ideas for the colors/fonts/sizes? I think the text color/size but I struggled with this a bit without figuring anything out.
- In the screenshots, you will notice trailing commas in the text. Should I duplicate the current strings but without the commas? Or remove the commas from the existing strings?
- When the progress bar is updated, it occasionally jumps back to the original percentage for a frame and then updates. Do you know what is causing this or how to fix it? I have trouble reproducing it in the first place but it is most noticeable in the seconds progress bar.
- Long term: there are now several time related utils with similar functionality in Utils.kt. Do you have any ideas for how to refactor these effectively? 

# Screenshots
![image](https://user-images.githubusercontent.com/120999438/216224327-6cc79db4-8fd4-49c3-939c-fd2e8360483e.png)

![image](https://user-images.githubusercontent.com/120999438/216224367-8dcfd0f7-81ac-4646-ac3e-f1c52259d94a.png)

![image](https://user-images.githubusercontent.com/120999438/216224521-49c97cfe-cf18-43af-8c33-490a33787de9.png)

![image](https://user-images.githubusercontent.com/120999438/216224601-15335a0e-74a8-4883-9e1a-c7fe471db159.png)

# Related issues
closes #97 