### PR TITLE
Add about section to setting

### DIFF
--- a/app/src/main/java/com/katiearose/sobriety/activities/Settings.kt
+++ b/app/src/main/java/com/katiearose/sobriety/activities/Settings.kt
@@ -9,6 +9,7 @@ import android.text.InputType
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.preference.*
+import com.katiearose.sobriety.BuildConfig
 import com.katiearose.sobriety.R
 import com.katiearose.sobriety.shared.CacheHandler
 import com.katiearose.sobriety.utils.applyThemes
@@ -89,6 +90,15 @@ class Settings : AppCompatActivity() {
             }
             findPreference<Preference>("data_import")?.setOnPreferenceClickListener {
                 getImport.launch(arrayOf<String>("application/json"))
+                true
+            }
+
+            findPreference<Preference>("pref_app_version")?.summary = BuildConfig.VERSION_NAME
+
+            findPreference<Preference>("pref_app_issue_tracker")?.setOnPreferenceClickListener {
+                val i = Intent(Intent.ACTION_VIEW)
+                i.data = Uri.parse(requireContext().getString(R.string.app_issue_url))
+                startActivity(i)
                 true
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_name">Sobriety</string>
+    <string name="app_issue_url">https://github.com/KiARC/Sobriety/issues</string>
+    <string name="app_license">GPL v3.0</string>
     <string name="prompt">To add an addiction to the tracker, press the \"+\" button in the bottom right corner.</string>
     <string name="add_new_addiction">Add new addiction</string>
     <string name="addiction_name">Addiction name</string>
@@ -132,6 +134,11 @@
     <string name="data">Data</string>
     <string name="data_export">Export</string>
     <string name="data_import">Import</string>
+    <string name="about">About</string>
+    <string name="version">Version</string>
+    <string name="report_an_issue">Report an issue</string>
+    <string name="opens_issue_tracker">Opens issue tracker</string>
+    <string name="license">License</string>
     <string name="average_attempts_window_pref">Number of Relapses (0 to disable)</string>
     <string name="summary">Summary</string>
 </resources>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -109,4 +109,29 @@
 
     </PreferenceCategory>
 
+    <PreferenceCategory app:title="@string/about"
+        app:iconSpaceReserved="false">
+
+        <Preference
+            app:key="pref_app_version"
+            app:persistent="false"
+            app:title="@string/version"
+            app:iconSpaceReserved="false" />
+
+        <Preference
+            app:key="pref_app_issue_tracker"
+            app:persistent="false"
+            app:title="@string/report_an_issue"
+            app:summary="@string/opens_issue_tracker"
+            app:iconSpaceReserved="false" />
+
+        <Preference
+            app:key="pref_app_license"
+            app:persistent="false"
+            app:title="@string/license"
+            app:summary="@string/app_license"
+            app:iconSpaceReserved="false" />
+
+    </PreferenceCategory>
+
 </PreferenceScreen>


### PR DESCRIPTION
Implements [Issue 63](https://github.com/KiARC/Sobriety/issues/63) with :

- App version number from the BuildConfig
- Issue button which opens the github issue tracker for the project
- App license

![About section preview](https://github.com/KiARC/Sobriety/assets/39135270/9c79c09e-0f9e-49bd-9c61-994e8ae46528)
